### PR TITLE
🌱 Update deploy.sh - Differentiate between build and run

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -109,8 +109,9 @@ rm -rf "${TEMP_IRONIC_OVERLAY}"
 mkdir -p "${TEMP_BMO_OVERLAY}"
 mkdir -p "${TEMP_IRONIC_OVERLAY}"
 
+KUSTOMIZE_BUILD="tools/bin/kustomize"
 KUSTOMIZE="${SCRIPTDIR}/tools/bin/kustomize"
-make -C "$(dirname "$0")/.." "${KUSTOMIZE}"
+make -C "$(dirname "$0")/.." "${KUSTOMIZE_BUILD}"
 
 #
 # Generate credentials as needed


### PR DESCRIPTION
The deploy.sh looked at ${SCRIPTDIR}, which then when called, skips the Makefile leaving no target to build against, which is looking for "tools/bin/kustomize" specifically.

Breaking out the build phase to a separate variable achieves this without breaking any other functionality.

**What this PR does / why we need it**:
Without this, deploy.sh can potentially fail to build kustomize during run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
